### PR TITLE
Mention complex alarms setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ used to populate Alerta attributes in those triggered alerts:
 
 | **Prometheus**         | Type          | **Alerta**   |
 -------------------------|---------------|---------------
-| instance      (*)      | internal      | resource     |
+| instance      (*)      | internal      | resource *   |
 | alertname     (*)      | internal      | event        |
 | environment            | label         | environment  |
 | severity               | label         | severity (+) |
@@ -87,6 +87,20 @@ used to populate Alerta attributes in those triggered alerts:
 Prometheus labels marked with a star (*) are built-in and assignment to
 Alerta attributes happens automatically. All other labels or annotations
 are user-defined and completely optional as they have sensible defaults.
+
+Be awere that during setting up complex alarms with sum and rate function 
+`instance` and `exported_instance` label can be missed from alarm. So you 
+have to set it up manualy. That way
+```
+ALERT ...rate_too_low 
+  IF sum by (host) (rate(....)) < 10
+  FOR 2m
+  LABELS {
+    value = "{{$value}}",
+    environment = "Production",
+    instance = "{{$labels.host}}"
+  }
+```
 
 Much more value can be obtained from the Alerta console if reasonable
 values are assigned where possible. This is demonstrated in the example


### PR DESCRIPTION
according to https://github.com/prometheus/alertmanager/blob/45bd4fd3e55a9269c3afa8c4c49825883ed1a031/notify/impl.go#L159
mapping table from https://github.com/alerta/prometheus-config
looks bad.
Prometheus alert may not contain instance or even exported_instance for example for such alert
sum(rate(...) BY (host) < 10
as a result information about instance is lost completely.
maybe there need to mention that fact.