### PR TITLE
Update wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ receivers:
 Configuration - Rules
 ---------------------
 
-Alertmanager rules define thresholds at which alerts should be triggered.
+Prometheus rules define thresholds at which alerts should be triggered.
 The following table illustrates how Prometheus notification data is
 used to populate Alerta attributes in those triggered alerts:
 


### PR DESCRIPTION
There's really no such thing as `Alertmanager rules`, as Alertmanager only handles the receivers and routes. Changing this to `Prometheus rules` to avoid confusion.