### PR TITLE
README.md: Add missing /api to webhook path

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Alertmanager config file.
 receivers:
 - name: "alerta"
   webhook_configs:
-  - url: 'http://localhost:8080/webhooks/prometheus'
+  - url: 'http://localhost:8080/api/webhooks/prometheus'
     send_resolved: true
 ```
 
@@ -72,7 +72,7 @@ receivers:
 receivers:
 - name: "alerta"
   webhook_configs:
-  - url: 'http://localhost:8080/webhooks/prometheus?api-key=QBPALlsFSkokm-XiOSupkbpK4SJdFBtStfrOjcdG'
+  - url: 'http://localhost:8080/api/webhooks/prometheus?api-key=QBPALlsFSkokm-XiOSupkbpK4SJdFBtStfrOjcdG'
     send_resolved: true
 ```
 


### PR DESCRIPTION
@satterly 

README.md correctly documents the webhook path as /api/webhooks/prometheus,
but in two examples /api was missing.